### PR TITLE
Added support for Liferay 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,8 @@ Liferay 7.1:
 Liferay 7.2:
     mvn -Dliferay=72 clean package
 
+Liferay 7.3:
+    mvn -Dliferay=73 clean package
+
 The required artifacts can be found in `modules/o365-package/target/o365-package-*.zip/`
     

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -271,5 +271,28 @@
 				</dependencies>
 			</dependencyManagement>
 		</profile>
+		<profile>
+			<id>liferay-73</id>
+			<activation>
+				<property>
+					<name>liferay</name>
+					<value>73</value>
+				</property>
+			</activation>
+			<properties>
+				<liferay.target.platform>7.3.4</liferay.target.platform>
+				<liferay.workspace.target.platform.version>7.3.4</liferay.workspace.target.platform.version>
+				<bundle.suffix>-lf73</bundle.suffix>
+			</properties>
+			<dependencyManagement>
+				<dependencies>
+					<dependency>
+						<artifactId>portlet-api</artifactId>
+						<groupId>javax.portlet</groupId>
+						<version>2.0</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
Added a new profile to maven compilaton setting the `liferay.workspace.target.platform.version` so the right versions from liferay kernel are imported.

You can test it by comipiling the modules (`mvn -Dliferay=73 clean package`) and deploying them to a Liferay 7.3